### PR TITLE
Proxy refactor

### DIFF
--- a/.wp-env.json
+++ b/.wp-env.json
@@ -1,0 +1,10 @@
+{
+    "core": null,
+    "plugins": [ "." ],
+    "phpVersion": "8.0",
+    "config": {
+        "WP_DEBUG": true,
+        "WP_DEBUG_LOG": true,
+        "WP_DEBUG_DISPLAY": true
+    }
+}

--- a/README.md
+++ b/README.md
@@ -74,6 +74,10 @@ See the plugin settings page for all possible options
 
 ## Changelog
 
+### 1.6.1
+
+Performs a refactor of the plugin, fixing a bug in the proxy logic, adding more documentation to docblocks, improving security issues, and decoupling proxy logic into a specific test method for the proxy connection and a generalised POST /sync method.
+
 ### 1.6.0
 
 Introduce proxy logic, so users can make urlbox screenshot requests via their proxy which is set in the plugin settings.
@@ -112,17 +116,39 @@ Fixed minor bugs and tested with Wordpress 5.7-beta
 
 Initial Release!
 
-## Releasing/Updating the Plugin on Wordpress
+## Testing
 
-[URLBox Screenshots Wordpress Plugin Homepage](https://wordpress.org/plugins/urlbox-screenshots/#developers)
+There are two ways to test the plugin easily, one with the wordpress playground, and the other using wp-env.
 
-### Testing
+To install wp env make sure you have Node installed and Docker. Make sure docker is running!
 
-You can test the plugin by zipping it from the root file, then importing the zipped file using a locally running Wordpress instance, or using this playground:
+Install: `npm -g i @wordpress/env`
+
+wp-env uses a config file held in this directory (wp-env.json). Make sure you're in this directory in your terminal, then run:
+
+`WP_ENV_PORT=3333 wp-env start`
+
+This will set the exposed port to 3333 instead of 8888 which some people often have in use. You can change this port to whatever you wish that is unused.
+
+You can change wordpress and php versions by changing the wp-env.json:
+
+```JSON
+    "core": "Wordpress/WordPress#6.0",
+    "phpVersion": "8.0",
+```
+
+Will change to wordpress version 6.0 and PHP 8.0 on rerunning wp-env start.
+
+You can also test the plugin by zipping it from the root file, then importing the zipped file in this playground:
 
 '''https://playground.wordpress.net/?storage=browser&php=8.0&wp=6.5&networking=yes'''
 
 Ensure that you're on at least PHP 8, Wordpress 6.5 and you have networking enabled.
+
+## Releasing/Updating the Plugin on Wordpress
+
+[URLBox Screenshots Wordpress Plugin Homepage](https://wordpress.org/plugins/urlbox-screenshots/#developers)
+
 
 ### Overview
 

--- a/readme.txt
+++ b/readme.txt
@@ -2,9 +2,9 @@
 Contributors: Chris Roebuck, Ankur Gurha, James Ogilvie, Arnold Cubici-Jones
 Author: Urlbox
 Tags: screenshot,screenshots,puppeteer,playwright,url to png
-Requires at least: 3.3
-Tested up to: 6.5
-Stable tag: 1.6.0
+Requires at least: 6.0
+Tested up to: 6.6.1
+Stable tag: 1.6.1
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 
@@ -15,6 +15,8 @@ License URI: http://www.gnu.org/licenses/gpl-2.0.html
 This plugin uses the Urlbox API to generate website screenshots and display them on your site. Please note the Urlbox API is a paid service - you can sign up for a trial at <https://urlbox.com>.
 
 **How to use the plugin**
+
+When running Wordpress locally or in a containerised environment, we recommend you use at least Wordpress version 6.0 and PHP 8.0.
 
 1. First activate the plugin and fill in your Urlbox.com API Key and Secret in the settings page.
 
@@ -40,8 +42,8 @@ The plugin wraps the `<img>` element inside a `<figure>` element. You can set th
 
 == Installation ==
 
-1. Upload the Urlbox plugin directory to the `/wp-content/plugins/urlbox` directory or install using the WordPress plugin installer
-2. Activate the plugin through the **Plugins** menu in WordPress
+1. Upload the Urlbox plugin directory to the `/wp-content/plugins/urlbox` directory or install using the Wordpress plugin installer
+2. Activate the plugin through the **Plugins** menu in Wordpress
 3. Edit default settings as necessary using **Urlbox Options**
 4. Create a new page or post, or edit an existing one
 5. Insert your shortcode using the Shortcode block
@@ -62,9 +64,13 @@ See <https://urlbox.com/docs/options> for default values
 
 == Known Bugs ==
 
-* None at this time
+1.6.0 - Bug in proxy logic. Testing one's proxy connection in the plugin's settings will not work due to an 'Invalid JSON' error, because of a lack of JSON encoding. This error does not display in the Wordpress playground, but will display in any dockerised/live environment. Action taken was to fix the bug and release 1.6.1, and introduce a dockerised test/development environment for future coverage before releases.
 
 == Changelog ==
+
+= 1.6.1 =
+
+Performs a refactor of the plugin, fixing a bug in the proxy logic, adding more documentation to docblocks, improving security issues, and decoupling proxy logic into a specific test method for the proxy connection and a generalised POST /sync method.
 
 = 1.6.0 =
 


### PR DESCRIPTION
This PR aims primarily to fix an issue with the recent introduction of Proxies into the Urlbox Wordpress plugin.

It also performs some cleanup/refactoring to make the developer experience easier to navigate.

This has been tested with wp-env rather than the wordpress playground, in wordpress versions 6.0 up to the latest 6.6.1 and PHP version 8.0.

It:

- Fixes a bug where when one tests their proxy connection an error "Error: INVALID JSON" would be returned from the UrlBox API.

This occurred because the $body of the request was not being JSON encoded in the proxy_fetch_render_url() method.

When using the Wordpress playground provided by Wordpress themselves, this error would not occur, and somewhere in the stack the $body would be automatically encoded, meaning that if wp_json_encode() was used to encode the body of the POST request, it would double encode it and the Urlbox API would then return a different error (400 bad request). **_Using the wordpress playground alone as a test harness is not sufficient going forward_**

Using the NPM package wp-env, which runs Wordpress in a docker container, the error reported was able to be replicated. After adding wp_json_encode() the issue was resolved.

- Refactors the proxy_fetch_render method to be a generic method for POST /sync.

The proxy_fetch_render_url() method was tied to the logic of testing that a proxy render works. Decoupling this allows any usage of the POST /sync endpoint to also include additional options, rather than just the 'url' and 'proxy' options. Future features will benefit from this decoupling, should specific POST /sync requests be required for a purpose other than proxy requests.

- Adds detailed docblocking for methods

A new developer trying to gain an understanding of what the plugin does, without prior knowledge of PHP or developing Wordpress plugins, may have struggled to understand the flow and purpose of methods in this file. Fleshing out dockblocks with @params/@return statements, as well as brief descriptions of the purpose of each method, was added to the file where appropriate or the method not self-explanatory. This will help future devs understand the inner workings of the plugin with more ease.

- Adds some generic constants and helper function

A function to remove and filter forbidden and empty keys has been added, so that it can be used before the point of request to the Urlbox API. This ensures that sensitive keys aren't unnecessarily sent across the wire to the API which would otherwise be unused.

Constants have been introduced at the start of the class definition. Though these haven't been referenced everywhere, they should be over time. This will save re-typing, and reduce human error/wasted time debugging misspelt keys.

- Adds key checks

Where appropriate checks have been added to ensure keys are set before array key accessing them.